### PR TITLE
Update getmailrc.example

### DIFF
--- a/getmailrc.example
+++ b/getmailrc.example
@@ -11,7 +11,7 @@ path = /opt/rt5/bin/rt-mailgate
 user = rt
 group = rt
 # 8080 is the mailgate vhost
-arguments = ("--url", "http://nginx:8080/", "--queue", "general", "--action", "comment")
+arguments = ("--url", "http://nginx:8080/", "--queue", "general", "--action", "correspond",)
 
 [options]
 read_all = false


### PR DESCRIPTION
According to the [docs](https://rt-wiki.bestpractical.com/wiki/Fetchmail), every item has to end with a comma. I would change the `comment` to `correspondence` for the box, as well, to make it act like a typical gateway for e-mails. Making it `comment` wouldn't run all the required scrips.

If these changes are not ok for your scenario, I would at least add a comment to point this thing out. Best with the link to the docs: https://rt-wiki.bestpractical.com/wiki/ManualInstallation#Receiving_email

Thanks again for a great image! It saved me hours.