### PR TITLE
doc: fix example command in readme for rtir ugprade

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -128,7 +128,7 @@ docker compose -f docker-compose.yml run --rm rt bash -c 'cd /opt/rt5 && perl ./
 To upgrade
 
 ```bash
-docker compose -f docker-compose.yml run --rm rt bash -c 'cd /opt/rt5 && perl ./sbin/rt-setup-database --action upgrade --skip-create --datadir /opt/rtir --package RT::IR --ext-version 5.0.4'
+docker compose -f docker-compose.yml run --rm rt bash -c 'cd /opt/rt5 && perl ./sbin/rt-setup-database --action upgrade --skip-create --datadir /opt/rtir/upgrade --package RT::IR --ext-version 5.0.4'
 ```
 
 Restart Webserver after all steps to fully load RT-IR


### PR DESCRIPTION
Read #33 

```
perl ./sbin/rt-setup-database --action upgrade --skip-create --datadir /opt/rtir/upgrade --package RT::IR --ext-version 5.0.4
Working with:
Type:	Pg
Host:	postgres
Port:	5432
Name:	rtdb
User:	rt
DBA:	rt (No DBA)
Enter RT::IR version you're upgrading from: 5.0.3

Going to apply following upgrades:
* 5.0.4

Enter RT::IR version if you want to stop upgrade at some point,
  or leave it blank if you want apply above upgrades: 

IT'S VERY IMPORTANT TO BACK UP BEFORE THIS STEP

Proceed [y/N]:y
Processing 5.0.4
Now inserting data.
Done.

```